### PR TITLE
Don't strictly require s2cloudless

### DIFF
--- a/cloudbuster/gather.py
+++ b/cloudbuster/gather.py
@@ -44,7 +44,6 @@ import requests
 import scipy.ndimage
 import torch
 import torchvision
-from s2cloudless import S2PixelCloudDetector
 
 
 def read_text(uri: str) -> str:
@@ -246,6 +245,8 @@ def gather(sentinel_path: str,
 
     # Get s2cloudless cloud mask.  This is always on L1C imagery.
     if not backstop and s2cloudless is not False and kind == 'L1C' and donor_mask is None:
+        from s2cloudless import S2PixelCloudDetector
+
         width_16 = width//16
         height_16 = height//16
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,5 @@ setup(name='cloudbuster',
       author_email='[email protected]',
       license='MIT',
       packages=['cloudbuster'],
-      install_requires=[
-          's2cloudless',
-      ],
       scripts=['cloudbuster/query_rf.py', 'cloudbuster/filter.py', 'cloudbuster/gather.py', 'cloudbuster/merge.py', 'python/meta-gather.py', 'python/meta-merge.py'],
       zip_safe=False)


### PR DESCRIPTION
s2cloudless requires pyproj>=2.2.0.  This is a problem for raster-vision, which currently requires pyproj < 2 to function properly.  Since s2cloudless is not strictly needed to run cloud-buster jobs, it should not be included in the `install_requires` list.