### PR TITLE
Provide helper materials for AWS Batch deployments

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,6 @@
+FROM jamesmcclain/aws-batch-ml:9
+LABEL author="James McClain <jmcclain@azavea.com>"
+LABEL description="Download Sentinel-2 L1C Imagery"
+
+COPY . /opt/src
+RUN pip install /opt/src

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Build application for staging or a release.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        echo "Building cloud-buster container image"
+        docker build -t cloud-buster -f Dockerfile .
+    fi
+fi

--- a/docker/ecr_publish
+++ b/docker/ecr_publish
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Expects CLOUDBUSTER_ECR_IMAGE env var to be set to <ecr_repo_name>:<tag_name>
+
+IMAGE_NAME="cloud-buster"
+ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
+AWS_REGION="us-east-1"
+
+aws ecr get-login --no-include-email --region ${AWS_REGION} | bash;
+docker tag ${IMAGE_NAME} \
+	${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLOUDBUSTER_ECR_IMAGE}
+docker push \
+	${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLOUDBUSTER_ECR_IMAGE}

--- a/docker/job-definition.template
+++ b/docker/job-definition.template
@@ -1,0 +1,53 @@
+{
+    "jobDefinitionName": "cloud-buster",
+    "type": "container",
+    "parameters": {},
+    "containerProperties": {
+        "image": "jamesmcclain/aws-batch-ml:9",
+        "vcpus": 2,
+        "memory": 8000,
+        "command": [],
+        "environment": [
+            {
+                "name": "RFTOKEN",
+                "value": "${RFTOKEN}"
+            },
+            {
+                "name": "LC_ALL",
+                "value": "C.UTF-8"
+            },
+            {
+                "name": "LANG",
+                "value": "C.UTF-8"
+            }
+        ],
+        "volumes": [
+            {
+                "host": {
+                    "sourcePath": "/home/ec2-user"
+                },
+                "name": "home"
+            },
+            {
+                "host": {
+                    "sourcePath": "/dev/shm"
+                },
+                "name": "shm"
+            }
+        ],
+        "mountPoints": [
+            {
+                "containerPath": "/opt/data",
+                "readOnly": false,
+                "sourceVolume": "home"
+            },
+            {
+                "containerPath": "/dev/shm",
+                "readOnly": false,
+                "sourceVolume": "shm"
+            }
+        ],
+        "ulimits": [],
+        "resourceRequirements": []
+    }
+}

--- a/docker/make-job-definition
+++ b/docker/make-job-definition
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Expects RFTOKEN env var to be set containing RF refresh token
+
+IMAGE_NAME="cloud-buster"
+export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
+export AWS_REGION="us-east-1"
+
+# aws ecr get-login --no-include-email --region ${AWS_REGION} | bash;
+# docker tag ${IMAGE_NAME} \
+#	${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLOUDBUSTER_ECR_IMAGE}
+# docker push \
+# 	${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${CLOUDBUSTER_ECR_IMAGE}
+
+cat ./docker/job-definition.template | envsubst


### PR DESCRIPTION
If CB is intended to be deployed on AWS Batch, it might be nice to provide some clues as to how to set up the infrastructure.  This is as much a discussion piece as a specific proposal, so I'm putting it up in this initial rough (and non-functioning) state, so that if it's deemed worthwhile, we can collectively guide the work towards something useful, but not too expansive.  

The general outlines are to provide some baseline templates for job queue and job definition setup that can provide a minimal working environment, specify a docker image that includes `cloudbuster`, and scripts to build and upload that image to ECR as well as deploy the template job def with a reference to the published image.